### PR TITLE
Adding the ability to set provenance hash

### DIFF
--- a/smart-contracts/.env.sample
+++ b/smart-contracts/.env.sample
@@ -25,6 +25,9 @@ POLYGONSCAN_API_KEY=
 # Token Base URI for NFT collection
 BASE_URI=https://gateway.pinata.cloud/ipfs/QmUjdsenuQvopTAubZNUKdaZjYVR8Kpo6nbDYJxyqpgRF2 # modify as needed
 
+# For setting provenance hash (Optional)
+PROVENANCE_HASH= 
+
 # Token Collection URI
 COLLECTION_URI=https://gateway.pinata.cloud/ipfs/QmTYo65YBGZe1GCUPG1G4QcaRmVukRNypSUVcGQPLsjzsj # modify as needed
 

--- a/smart-contracts/contracts/nft.sol
+++ b/smart-contracts/contracts/nft.sol
@@ -297,8 +297,8 @@ contract MyNFT is ERC721, IERC2981, Ownable, ReentrancyGuard {
         collectionURI = _collectionURI;
     }
     
-    function setProvenanceHash(string calldata hash) public onlyOwner {
-        PROVENANCE_HASH = hash;
+    function setProvenanceHash(string calldata _hash) public onlyOwner {
+        provenanceHash = _hash;
     }
 
     function setRoyaltyReceiverAddress(address _royaltyReceiverAddress)

--- a/smart-contracts/contracts/nft.sol
+++ b/smart-contracts/contracts/nft.sol
@@ -21,6 +21,8 @@ contract MyNFT is ERC721, IERC2981, Ownable, ReentrancyGuard {
     string private baseURI;
 
     string private collectionURI;
+    
+    string public PROVENANCE_HASH;
 
     uint256 public numReservedTokens;
 
@@ -293,6 +295,10 @@ contract MyNFT is ERC721, IERC2981, Ownable, ReentrancyGuard {
 
     function setCollectionURI(string memory _collectionURI) external onlyOwner {
         collectionURI = _collectionURI;
+    }
+    
+    function setProvenanceHash(string calldata hash) public onlyOwner {
+        PROVENANCE_HASH = hash;
     }
 
     function setRoyaltyReceiverAddress(address _royaltyReceiverAddress)

--- a/smart-contracts/contracts/nft.sol
+++ b/smart-contracts/contracts/nft.sol
@@ -22,7 +22,7 @@ contract MyNFT is ERC721, IERC2981, Ownable, ReentrancyGuard {
 
     string private collectionURI;
     
-    string public PROVENANCE_HASH;
+    string public provenanceHash;
 
     uint256 public numReservedTokens;
 

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -21,7 +21,7 @@
     "giftTokens": "npx hardhat run scripts/giftTokens.js",
     "reserveTokens": "npx hardhat run scripts/reserveTokens.js",
     "setBaseURI": "npx hardhat run scripts/setBaseURI.js",
-     "setProvenanceHash": "npx hardhat run scripts/setProvenanceHash.js"
+    "setProvenanceHash": "npx hardhat run scripts/setProvenanceHash.js",
     "setPublicSaleActive": "npx hardhat run scripts/setPublicSaleActive.js",
     "setPresaleActive": "npx hardhat run scripts/setPreSaleActive.js",
     "setSaleInactive": "npx hardhat run scripts/setSaleInactive.js",

--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -21,6 +21,7 @@
     "giftTokens": "npx hardhat run scripts/giftTokens.js",
     "reserveTokens": "npx hardhat run scripts/reserveTokens.js",
     "setBaseURI": "npx hardhat run scripts/setBaseURI.js",
+     "setProvenanceHash": "npx hardhat run scripts/setProvenanceHash.js"
     "setPublicSaleActive": "npx hardhat run scripts/setPublicSaleActive.js",
     "setPresaleActive": "npx hardhat run scripts/setPreSaleActive.js",
     "setSaleInactive": "npx hardhat run scripts/setSaleInactive.js",

--- a/smart-contracts/scripts/setProvenanceHash.js
+++ b/smart-contracts/scripts/setProvenanceHash.js
@@ -4,7 +4,7 @@ const hre = require("hardhat");
 async function main() {
   const PROVENANCE_HASH = process.env.PROVENANCE_HASH;
   if (!PROVENANCE_HASH) {
-    console.log("BASE_URI is required. Please add it to your environment.");
+    console.log("PROVENANCE_HASH is required. Please add it to your environment.");
     return;
   }
 

--- a/smart-contracts/scripts/setProvenanceHash.js
+++ b/smart-contracts/scripts/setProvenanceHash.js
@@ -8,11 +8,11 @@ async function main() {
     return;
   }
 
-  const TechnoFeudal = await hre.ethers.getContractFactory("TechnoFeudal");
-  const nft = await TechnoFeudal.attach(
+  const MyNFT = await hre.ethers.getContractFactory("MyNFT");
+  const nft = await MyNFT.attach(
     process.env.CONTRACT_ADDRESS // The deployed contract address
   );
-  console.log("TechnoFeudal attached to:", nft.address);
+  console.log("MyNFT attached to:", nft.address);
 
   console.log("setting Provenance Hash..", PROVENANCE_HASH);
 

--- a/smart-contracts/scripts/setProvenanceHash.js
+++ b/smart-contracts/scripts/setProvenanceHash.js
@@ -1,0 +1,27 @@
+require("dotenv").config();
+const hre = require("hardhat");
+
+async function main() {
+  const PROVENANCE_HASH = process.env.PROVENANCE_HASH;
+  if (!PROVENANCE_HASH) {
+    console.log("BASE_URI is required. Please add it to your environment.");
+    return;
+  }
+
+  const TechnoFeudal = await hre.ethers.getContractFactory("TechnoFeudal");
+  const nft = await TechnoFeudal.attach(
+    process.env.CONTRACT_ADDRESS // The deployed contract address
+  );
+  console.log("TechnoFeudal attached to:", nft.address);
+
+  console.log("setting Provenance Hash..", PROVENANCE_HASH);
+
+  const res = await nft.setProvenanceHash(PROVENANCE_HASH);
+
+  console.log("set Provenance Hash", res);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
The provenance hash is an important feature for establishing trust between customer and seller if a reveal is occurring. Noticed it was not in the contract so decided to add the functionality in both contract and package.json commands.